### PR TITLE
Add clippy workflow check and remove feature inner attribute

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,11 @@
-name: Rust
-
-on: [push]
-
+on: push
+name: Rust build and test
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
     - name: Build
-      run: cargo build --verbose
+      run: cargo build
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,11 @@
+on: push
+name: Clippy check
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - name: Clippy
+        run: cargo clippy
+        

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 // implied.  See the License for the specific language governing
 // permissions and limitations under the License.
 
-#![feature(async_closure)]
-
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
This commit adds a clippy workflow check and removes the use of
`#[feature(async_closure]` since the code compiles and tests passes
without it.