### PR TITLE
Refactor to use Strategy trait

### DIFF
--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -12,7 +12,7 @@ use tokio::net::{TcpListener, TcpStream};
 
 pub struct TcpSession {
     source: SocketAddr,
-    strategy: Strategy,
+    strategy: Box<dyn Strategy + Send>,
 }
 
 /// A TCP session.
@@ -20,7 +20,7 @@ pub struct TcpSession {
 /// The TCP session will listen for connections on the provided port
 /// and send to the provided destination.
 impl TcpSession {
-    pub fn new(source: SocketAddr, strategy: Strategy) -> TcpSession {
+    pub fn new(source: SocketAddr, strategy: Box<dyn Strategy + Send>) -> TcpSession {
         TcpSession { source, strategy }
     }
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -20,14 +20,14 @@ use tokio::net::UdpSocket;
 
 pub struct UdpSession {
     source: SocketAddr,
-    strategy: Strategy,
+    strategy: Box<dyn Strategy + Send>,
 }
 
 /// An UDP session that will listen on one socket and send the packets
 /// to one or more other sockets.
 impl UdpSession {
     /// Create a new session
-    pub fn new(source: SocketAddr, strategy: Strategy) -> UdpSession {
+    pub fn new(source: SocketAddr, strategy: Box<dyn Strategy + Send>) -> UdpSession {
         UdpSession { source, strategy }
     }
 


### PR DESCRIPTION
In preparation for supporting custom strategies, the code is refactored
to use a `Strategy` trait and a factory method is added to construct
specific trait objects.